### PR TITLE
Fix hardcoded timeout in MongoConnectException message.

### DIFF
--- a/src/Hangfire.Mongo/MongoConnectException.cs
+++ b/src/Hangfire.Mongo/MongoConnectException.cs
@@ -13,9 +13,10 @@ namespace Hangfire.Mongo
         /// </summary>
         /// <param name="dbContext"></param>
         /// <param name="connectionString"></param>
+        /// <param name="connectionCheckTimeout"></param>
         /// <param name="e"></param>
-        public MongoConnectException(HangfireDbContext dbContext, string connectionString, Exception e) 
-            : base($"\r\nDid not receive ping response from '{dbContext.Database.DatabaseNamespace.DatabaseName}' within 1000ms\r\n" +
+        public MongoConnectException(HangfireDbContext dbContext, string connectionString, TimeSpan connectionCheckTimeout, Exception e) 
+            : base($"\r\nDid not receive ping response from '{dbContext.Database.DatabaseNamespace.DatabaseName}' within {connectionCheckTimeout.TotalMilliseconds}ms\r\n" +
                    $"assuming not able to connect to '{connectionString}'\r\n" +
                    $"you can disable database ping via the MongoStorageOption 'CheckConnection' field\r\n", e)
         {

--- a/src/Hangfire.Mongo/MongoStorage.cs
+++ b/src/Hangfire.Mongo/MongoStorage.cs
@@ -98,7 +98,7 @@ namespace Hangfire.Mongo
                 }
                 catch (Exception e)
                 {
-                    throw new MongoConnectException(HangfireDbContext, CreateObscuredConnectionString(), e);
+                    throw new MongoConnectException(HangfireDbContext, CreateObscuredConnectionString(), StorageOptions.ConnectionCheckTimeout, e);
                 }
             }
         }


### PR DESCRIPTION
I noticed that while I was overriding `ConnectionCheckTimeout` the exception message remained the same, causing confusion.
Added the `ConnectionCheckTimeout` as a parameter in the `MongoConnectException` constructor in order to show the correct value in the error message.