### PR TITLE
Fix SchemaDto deserialization

### DIFF
--- a/src/Hangfire.Mongo/Dto/SchemaDto.cs
+++ b/src/Hangfire.Mongo/Dto/SchemaDto.cs
@@ -1,4 +1,5 @@
-﻿using MongoDB.Bson;
+﻿using System;
+using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace Hangfire.Mongo.Dto
@@ -29,7 +30,17 @@ namespace Hangfire.Mongo.Dto
             {
                 Identifier = identifier.StringOrNull();
             }
-            Version = (MongoSchema)doc["_id"].AsInt32;
+
+            var id = doc["_id"];
+            if (id.IsString)
+            {
+                // Before schema version 20, the _id was stored as a string
+                Version = (MongoSchema)Enum.Parse(typeof(MongoSchema), id.AsString);
+            }
+            else
+            {
+                Version = (MongoSchema)id.AsInt32;
+            }
         }
 
         /// <summary>

--- a/src/Hangfire.Mongo/MongoSchema.cs
+++ b/src/Hangfire.Mongo/MongoSchema.cs
@@ -1,4 +1,4 @@
-﻿namespace Hangfire.Mongo
+namespace Hangfire.Mongo
 {
 
     /// <summary>
@@ -92,7 +92,7 @@
         Version19 = 19,
 
         /// <summary>
-        /// Schema Version 19
+        /// Schema Version 20
         /// </summary>
         Version20 = 20
     }


### PR DESCRIPTION
Commit 9f5da1d458935d14309f6576ebaa4d7f916c630f (use manual serialization (#331)) does not properly handle the fact that before manual serialization `hangfire.schema._id` was stored as a string of the corresponding `MongoSchema` enum value.

With an existing `hangfire.schema` collection, the migration would fail with the following error:
```
System.InvalidCastException: Unable to cast object of type 'MongoDB.Bson.BsonString' to type 'MongoDB.Bson.BsonInt32'.
   at MongoDB.Bson.BsonValue.get_AsInt32()
   at Hangfire.Mongo.Dto.SchemaDto..ctor(BsonDocument doc)
   at lambda_method81(Closure , BsonDocument )
   at MongoDB.Bson.Serialization.Serializers.ProjectingDeserializer`2.Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
   at MongoDB.Bson.Serialization.IBsonSerializerExtensions.Deserialize[TValue](IBsonSerializer`1 serializer, BsonDeserializationContext context)
   at MongoDB.Driver.Core.Operations.CursorBatchDeserializationHelper.DeserializeBatch[TDocument](RawBsonArray batch, IBsonSerializer`1 documentSerializer, MessageEncoderSettings messageEncoderSettings)
   at MongoDB.Driver.Core.Operations.FindOperation`1.CreateFirstCursorBatch(BsonDocument cursorDocument)
   at MongoDB.Driver.Core.Operations.FindOperation`1.CreateCursor(IChannelSourceHandle channelSource, IChannelHandle channel, BsonDocument commandResult)
   at MongoDB.Driver.Core.Operations.FindOperation`1.Execute(RetryableReadContext context, CancellationToken cancellationToken)
   at MongoDB.Driver.Core.Operations.FindOperation`1.Execute(IReadBinding binding, CancellationToken cancellationToken)
   at MongoDB.Driver.OperationExecutor.ExecuteReadOperation[TResult](IReadBinding binding, IReadOperation`1 operation, CancellationToken cancellationToken)
   at MongoDB.Driver.MongoCollectionImpl`1.ExecuteReadOperation[TResult](IClientSessionHandle session, IReadOperation`1 operation, ReadPreference readPreference, CancellationToken cancellationToken)
   at MongoDB.Driver.MongoCollectionImpl`1.ExecuteReadOperation[TResult](IClientSessionHandle session, IReadOperation`1 operation, CancellationToken cancellationToken)
   at MongoDB.Driver.MongoCollectionImpl`1.FindSync[TProjection](IClientSessionHandle session, FilterDefinition`1 filter, FindOptions`2 options, CancellationToken cancellationToken)
   at MongoDB.Driver.MongoCollectionImpl`1.<>c__DisplayClass46_0`1.<FindSync>b__0(IClientSessionHandle session)
   at MongoDB.Driver.MongoCollectionImpl`1.UsingImplicitSession[TResult](Func`2 func, CancellationToken cancellationToken)
   at MongoDB.Driver.MongoCollectionImpl`1.FindSync[TProjection](FilterDefinition`1 filter, FindOptions`2 options, CancellationToken cancellationToken)
   at MongoDB.Driver.FindFluent`2.ToCursor(CancellationToken cancellationToken)
   at MongoDB.Driver.IAsyncCursorSourceExtensions.FirstOrDefault[TDocument](IAsyncCursorSource`1 source, CancellationToken cancellationToken)
   at MongoDB.Driver.IFindFluentExtensions.FirstOrDefault[TDocument,TProjection](IFindFluent`2 find, CancellationToken cancellationToken)
   at Hangfire.Mongo.Migration.MongoMigrationManager.GetCurrentSchema(IMongoDatabase database)
   at Hangfire.Mongo.Migration.MongoMigrationManager.Migrate(MongoBackupStrategy backupStrategy, MongoMigrationStrategy migrationStrategy)
   at Hangfire.Mongo.Migration.MongoMigrationManager.MigrateIfNeeded(MongoStorageOptions storageOptions, IMongoDatabase database)
   at Hangfire.Mongo.MongoStorage..ctor(IMongoClient mongoClient, String databaseName, MongoStorageOptions storageOptions)
   at Hangfire.Mongo.MongoStorage..ctor(MongoClientSettings mongoClientSettings, String databaseName, MongoStorageOptions storageOptions)
```