### PR TITLE
Remove debug log written with Console.WriteLine

### DIFF
--- a/src/Hangfire.Mongo/Migration/MigrationLock.cs
+++ b/src/Hangfire.Mongo/Migration/MigrationLock.cs
@@ -77,7 +77,6 @@ namespace Hangfire.Mongo.Migration
                         // If result is null, it means we acquired the lock
                         if (result == null)
                         {
-                            Console.WriteLine(($"Acquired lock for migration [{Thread.CurrentThread.ManagedThreadId}]"));
                             if (Logger.IsDebugEnabled())
                             {
                                 Logger.Debug("Acquired lock for migration");


### PR DESCRIPTION
The same log is already logged with the proper logging mechanism (which can be configured) 3 lines below.