### PR TITLE
Make all queries compatible with the LINQ V3 provider of MongoDB.Driver

### DIFF
--- a/src/Hangfire.Mongo.Tests/MongoDiscriminatorTests.cs
+++ b/src/Hangfire.Mongo.Tests/MongoDiscriminatorTests.cs
@@ -53,9 +53,8 @@ namespace Hangfire.Mongo.Tests
             {
                 ["_t"] = nameof(JobDto),
                 ["_id"] = ObjectId.Parse(jobId)
-            })
-                .Project(b => new JobDto(b))
-                .FirstOrDefault();
+            }).FirstOrDefault();
+
 
             // ASSERT
             Assert.NotNull(jobDto);

--- a/src/Hangfire.Mongo.Tests/MongoDistributedLockFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoDistributedLockFacts.cs
@@ -168,11 +168,9 @@ namespace Hangfire.Mongo.Tests
                 DateTime initialExpireAt = DateTime.UtcNow;
                 Thread.Sleep(TimeSpan.FromSeconds(5));
 
-                DistributedLockDto lockEntry = _database.DistributedLock
-                    .Find(filter)
-                    .Project(b => new DistributedLockDto(b)).FirstOrDefault();
+                var lockEntry = _database.DistributedLock.Find(filter).FirstOrDefault();
                 Assert.NotNull(lockEntry);
-                Assert.True(lockEntry.ExpireAt > initialExpireAt);
+                Assert.True(new DistributedLockDto(lockEntry).ExpireAt > initialExpireAt);
             }
         }
 
@@ -192,11 +190,7 @@ namespace Hangfire.Mongo.Tests
             };
             using (lock1.AcquireLock())
             {
-                var lockEntry = _database
-                    .DistributedLock
-                    .Find(filter)
-                    .Project(b => new DistributedLockDto(b))
-                    .Single();
+                var lockEntry = new DistributedLockDto(_database.DistributedLock.Find(filter).Single());
 
                 Assert.True(lockEntry.ExpireAt > initialExpireAt);
             }

--- a/src/Hangfire.Mongo/Migration/MongoMigrationManager.cs
+++ b/src/Hangfire.Mongo/Migration/MongoMigrationManager.cs
@@ -110,11 +110,8 @@ namespace Hangfire.Mongo.Migration
         /// <returns></returns>
         protected virtual SchemaDto GetCurrentSchema(IMongoDatabase database)
         {
-            return database
-                .GetCollection<BsonDocument>(_storageOptions.Prefix + ".schema")
-                .Find(new BsonDocument())
-                .Project(b => new SchemaDto(b))
-                .FirstOrDefault();
+            var document = database.GetCollection<BsonDocument>(_storageOptions.Prefix + ".schema").AsQueryable().FirstOrDefault();
+            return document == null ? null : new SchemaDto(document);
         }
     }
 }

--- a/src/Hangfire.Mongo/MongoMonitoringApi.cs
+++ b/src/Hangfire.Mongo/MongoMonitoringApi.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.Design;
 using System.Linq;
 using System.Threading.Tasks;
 using Hangfire.Common;
@@ -49,7 +50,7 @@ namespace Hangfire.Mongo
 
         public virtual IList<ServerDto> Servers()
         {
-            var servers = _dbContext.Server.Find(new BsonDocument()).Project(b => new Dto.ServerDto(b)).ToList();
+            var servers = _dbContext.Server.AsQueryable().ToList().Select(b => new Dto.ServerDto(b));
 
             var result = new List<ServerDto>();
 
@@ -424,8 +425,8 @@ namespace Hangfire.Mongo
             var jobs = _dbContext
                 .JobGraph
                 .Find(jobsByIdsFilter)
-                .Project(b => new JobDto(b))
-                .ToList();
+                .ToList()
+                .Select(b => new JobDto(b));
 
             var enqueuedJobs = jobs
                 .Select(job =>
@@ -509,8 +510,8 @@ namespace Hangfire.Mongo
             var jobs = connection
                 .JobGraph
                 .Find(filter)
-                .Project(b => new JobDto(b))
-                .ToList();
+                .ToList()
+                .Select(b => new JobDto(b));
 
             var fetcedJobs = jobs
                 .Select(job =>
@@ -563,8 +564,8 @@ namespace Hangfire.Mongo
                 .Sort(new BsonDocument("_id", -1))
                 .Skip(from)
                 .Limit(count)
-                .Project(b => new JobDto(b))
-                .ToList();
+                .ToList()
+                .Select(b => new JobDto(b));
 
             var joinedJobs = jobs
                 .Select(job =>
@@ -645,8 +646,8 @@ namespace Hangfire.Mongo
             };
             var valuesMap = _dbContext.JobGraph
                 .Find(filter)
-                .Project(b => new CounterDto(b))
                 .ToList()
+                .Select(b => new CounterDto(b))
                 .GroupBy(counter => counter.Key, counter => counter)
                 .ToDictionary(counter => counter.Key, grouping => grouping.Sum(c => c.Value));
 


### PR DESCRIPTION
The latest version of MongoDB.Driver (2.19.0) changes the default LINQ provider from V2 to V3 any many queries were incompatible with the new provider before this commit, throwing MongoDB.Driver.Linq.ExpressionNotSupportedException.

Fixes #338