### PR TITLE
Added version check for newer feature

### DIFF
--- a/src/Hangfire.Mongo/Database/HangfireDbContext.cs
+++ b/src/Hangfire.Mongo/Database/HangfireDbContext.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using Hangfire.Mongo.Dto;
+﻿using Hangfire.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using System;
 
 namespace Hangfire.Mongo.Database
 {
@@ -10,6 +10,8 @@ namespace Hangfire.Mongo.Database
     /// </summary>
     public sealed class HangfireDbContext
     {
+        private static readonly ILog Logger = LogProvider.For<HangfireDbContext>();
+
         private readonly string _prefix;
 
         /// <summary>
@@ -22,11 +24,16 @@ namespace Hangfire.Mongo.Database
         /// </summary>
         public IMongoDatabase Database { get; }
 
+        /// <summary>
+        /// Needed to check for features enabled only in certain versions of the database.
+        /// </summary>
+        private Version _version = new Version(0, 0);
+
         internal HangfireDbContext(string connectionString, string databaseName, string prefix = "hangfire")
-            :this(new MongoClient(connectionString), databaseName, prefix)
+            : this(new MongoClient(connectionString), databaseName, prefix)
         {
-            
         }
+
         /// <summary>
         /// Constructs context with Mongo client and database name
         /// </summary>
@@ -39,8 +46,56 @@ namespace Hangfire.Mongo.Database
             Client = mongoClient;
             Database = mongoClient.GetDatabase(databaseName);
             ConnectionId = Guid.NewGuid().ToString();
+
+            GetServerVersion();
         }
 
+        /// <summary>
+        /// Try to get server version, sometimes it can be useful to use certain feature only
+        /// if the version is greater than a minimum version.
+        /// </summary>
+        private void GetServerVersion()
+        {
+            //We cache version in memory, it is unlikely that the database changes version while the application is running and
+            //if we want to use newer feature it is a good idea to restart.
+            if (_version != null)
+            {
+                return;
+            }
+            try
+            {
+                //We need to get server version to check if we can user various features.
+                var adminDatabase = Client.GetDatabase("admin");
+
+                // Check the server version
+                var buildInfoCommand = new BsonDocumentCommand<BsonDocument>(new BsonDocument { { "buildInfo", 1 } });
+                var buildInfo = adminDatabase.RunCommand(buildInfoCommand);
+                var versionString = buildInfo.GetValue("version").AsString;
+                _version = Version.Parse(versionString);
+                if (Logger.IsInfoEnabled())
+                {
+                    Logger.InfoFormat("Mongodb version is {0}", _version);
+                }
+            }
+            catch (Exception e)
+            {
+                //we are unable to determine MongoDB Server version, this is a warning, now knowing a version will not cause
+                //any issues. Returning a version of 0 will ensure no new feature are used unless we are sure they are supported.
+                _version = new Version(0, 0);
+                Logger.WarnException("Failed to get Mongodb server version", e);
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the version if greater than or equal of required version.
+        /// </summary>
+        /// <param name="major"></param>
+        /// <param name="minor"></param>
+        /// <returns>True if the version greater than or equal to requested version.</returns>
+        public bool IsVersionGreaterThanOrEqualTo(int major, int minor)
+        {
+            return _version.Major > major || (_version.Major == major && _version.Minor >= minor);
+        }
 
         /// <summary>
         /// Mongo database connection identifier
@@ -52,7 +107,7 @@ namespace Hangfire.Mongo.Database
         /// </summary>
         public IMongoCollection<BsonDocument> Notifications =>
             Database.GetCollection<BsonDocument>(_prefix + ".notifications");
-        
+
         /// <summary>
         /// Reference to job graph collection
         /// </summary>


### PR DESCRIPTION
Actually we have the .NOW function that is introduced in 4.2. If you use a previous version of Mongodb you will find wou full of Warning log from GetUtcDateTime() method.

It would be really better to add the concept of retrieving the version of the server when you initialize the context and for such functions, just them only if they are supported and use a fallback otherwise.

We still have customer on older version of mongodb and upgrading to newer version of HAngfire.Mongo we have logs fill with warning. I know that we need to upgrade but is is always a good strategy to grab the version of the server and being able to check the version before using a new functionality, instead of relying on try/catch .

![image](https://github.com/Hangfire-Mongo/Hangfire.Mongo/assets/358545/f63bd42e-c19d-42cf-9f50-b4074dc23425)
