### PR TITLE
Improve performance of MongoMonitoringApi.GetQueues()

### DIFF
--- a/src/Hangfire.Mongo.Tests/MongoMonitoringApiFacts.cs
+++ b/src/Hangfire.Mongo.Tests/MongoMonitoringApiFacts.cs
@@ -372,6 +372,84 @@ namespace Hangfire.Mongo.Tests
             Assert.Equal(24, results.Count);
         }
 
+        [Fact]
+        public void GetQueues_ReturnsQueues()
+        {
+            CreateJobInState(_database, ObjectId.GenerateNewId(1), EnqueuedState.StateName, job =>
+            {
+                job.Queue = "queue_1";
+                return job;
+            });
+
+            CreateJobInState(_database, ObjectId.GenerateNewId(2), EnqueuedState.StateName, job =>
+            {
+                job.Queue = "queue_2";
+                return job;
+            });
+
+            CreateJobInState(_database, ObjectId.GenerateNewId(3), EnqueuedState.StateName, job =>
+            {
+                job.Queue = "queue_2";
+                return job;
+            });
+
+            var results = _monitoringApi.GetQueues();
+            
+            Assert.Equal(new[] { "queue_1", "queue_2" }, results);
+        }
+
+        [Fact]
+        public void GetQueues_ExcludesNullQueue()
+        {
+            CreateJobInState(_database, ObjectId.GenerateNewId(1), EnqueuedState.StateName, job =>
+            {
+                job.Queue = "queue_1";
+                return job;
+            });
+
+            CreateJobInState(_database, ObjectId.GenerateNewId(2), EnqueuedState.StateName, job =>
+            {
+                job.Queue = "queue_2";
+                return job;
+            });
+
+            CreateJobInState(_database, ObjectId.GenerateNewId(3), EnqueuedState.StateName, job =>
+            {
+                job.Queue = null;
+                return job;
+            });
+
+            var results = _monitoringApi.GetQueues();
+            
+            Assert.Equal(new[] { "queue_1", "queue_2" }, results);
+        }
+
+        [Fact]
+        public void GetStatistics_ReturnsQueueCount()
+        {
+            CreateJobInState(_database, ObjectId.GenerateNewId(1), EnqueuedState.StateName, job =>
+            {
+                job.Queue = "queue_1";
+                return job;
+            });
+
+            CreateJobInState(_database, ObjectId.GenerateNewId(2), EnqueuedState.StateName, job =>
+            {
+                job.Queue = "queue_2";
+                return job;
+            });
+
+            CreateJobInState(_database, ObjectId.GenerateNewId(3), EnqueuedState.StateName, job =>
+            {
+                job.Queue = "queue_2";
+                return job;
+            });
+
+            var statistics = _monitoringApi.GetStatistics();
+            
+            Assert.Equal(2, statistics.Queues);
+        }
+
         private JobDto CreateJobInState(HangfireDbContext dbContext, ObjectId jobId, string stateName, Func<JobDto, JobDto> visitor = null)
         {
             var job = Job.FromExpression(() => HangfireTestJobs.SampleMethod("wrong"));

--- a/src/Hangfire.Mongo/MongoMonitoringApi.cs
+++ b/src/Hangfire.Mongo/MongoMonitoringApi.cs
@@ -371,17 +371,13 @@ namespace Hangfire.Mongo
 
         public virtual IReadOnlyList<string> GetQueues()
         {
-            var pipeline = new BsonDocument[]
-            {
-                new BsonDocument("$match",
-                    new BsonDocument("_t", nameof(JobDto))),
-                new BsonDocument("$group", new BsonDocument("_id", $"${nameof(JobDto.Queue)}"))
-            };
             return _dbContext.JobGraph
-                .Aggregate<BsonDocument>(pipeline)
+                .Distinct(
+                    f => f[nameof(JobDto.Queue)],
+                    new BsonDocument("_t", nameof(JobDto)))
                 .ToList()
-                .Where(b => b["_id"] != BsonNull.Value)
-                .Select(b => b["_id"].AsString)
+                .Where(b => !b.IsBsonNull)
+                .Select(b => b.AsString)
                 .ToList();
         }
 


### PR DESCRIPTION
Instead of using an aggregation pipeline, which needs to scan the whole collection to get the results, use Mongo's "Distinct" command which is super fast.